### PR TITLE
Remove helper function empty_sprite (now built-in)

### DIFF
--- a/data/tf_util/tf_util.lua
+++ b/data/tf_util/tf_util.lua
@@ -170,17 +170,6 @@ util.empty_sound = function()
   }
 end
 
-util.empty_sprite = function()
-  return
-  {
-    filename = util.path("data/tf_util/empty-sprite.png"),
-    height = 1,
-    width = 1,
-    frame_count = 1,
-    direction_count = 1
-  }
-end
-
 util.damage_type = function(name)
   if not data.raw["damage-type"][name] then
     data:extend{{type = "damage-type", name = name, localised_name = {name}}}


### PR DESCRIPTION
This function exists in the vanilla's util.lua, and overwriting it here causes issues with the Upcycler mod.