### PR TITLE
Resurrected support for modded road tiles.

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -9,35 +9,6 @@ data:extend {
 }
 local tiles = data.raw.tile
 
-
-local road_list = {}
-local road_tile_list =
-{
-  type = "selection-tool",
-  name = "road-tile-list",
-  hidden = true,
-  icon = "__Transport_Drones_Meglinge_Fork__/data/tf_util/empty-sprite.png",
-  icon_size = 1,
-  tile_filters = {
-    "transport-drone-road",
-    "transport-drone-road-better"
-  },
-  stack_size = 1,
-  select =
-  {
-    border_color = { 1, 1, 1 },
-    mode = { "any-tile" },
-    cursor_box_type = "entity",
-  },
-  alt_select =
-  {
-    border_color = { 0, 1, 0 },
-    mode = { "any-tile" },
-    cursor_box_type = "entity",
-  }
-}
-data:extend { road_tile_list }
-
 local place_as_tile_condition = { layers = { water_tile = true } }
 
 if mods["space-exploration"] then
@@ -51,7 +22,6 @@ local process_road_item = function(item)
   local seen = {}
   while true do
     tile.collision_mask = { layers = { roadtd = true } }
-    table.insert(road_list, tile.name)
     seen[tile.name] = true
     tile = tiles[tile.next_direction or ""]
     if not tile then break end

--- a/script/proxy_tile.lua
+++ b/script/proxy_tile.lua
@@ -2,23 +2,8 @@
 
 local road_network = require("script/road_network")
 
-local road_tile_list_name = "road-tile-list"
-local road_tiles
-local tile_filters = {
-  "transport-drone-road",
-  "transport-drone-road-better"
-}
-local get_road_tiles = function()
-  if road_tiles then return road_tiles end
-  road_tiles = {}
-  for _, tile_name in pairs (tile_filters) do
-    road_tiles[tile_name] = true
-  end
-  return road_tiles
-end
-
 local is_road_tile = function(name)
-  return get_road_tiles()[name]
+  return road_network.get_road_tiles()[name]
 end
 
 local raw_road_tile_built = function(event)

--- a/script/road_network.lua
+++ b/script/road_network.lua
@@ -532,7 +532,7 @@ local floor = math.floor
 local road_tiles = nil
 local road_tile_names = nil
 
-local check_init_tiles = function()
+local get_or_init_tiles = function()
   if road_tiles then return road_tiles end
 
   local mask = prototypes.tile["transport-drone-road"].collision_mask
@@ -559,12 +559,12 @@ local check_init_tiles = function()
 end
 
 road_network.get_road_tiles = function()
-  check_init_tiles()
+  get_or_init_tiles()
   return road_tiles
 end
 
 road_network.get_road_tile_names = function()
-  check_init_tiles()
+  get_or_init_tiles()
   return road_tile_names
 end
 


### PR DESCRIPTION
This patch is the minimal changes I could make to re-enable support for modded road tiles. It is implemented slightly differently to how Klonan originally did it, because of the changes to the APIs. The data stage fixes up all the modded road surfaces with the correct collisions and stuff like that, but the upgrade planner that used to be used to store a list of road types is removed, as it can't be used any more. Then in the control stage, we lazy-instantiate a table of road surfaces and a list of road surface names. These are then used in each place where things need to check or loop over roads. It appear to work with all the asphalt paving roads including decorations. I have not tested with bobs or py, but I don't forsee this patch being responsible for any issues there.