### PR TITLE
fix fatal error when read info from a new fluid depot.

### DIFF
--- a/script/depots/fluid_depot.lua
+++ b/script/depots/fluid_depot.lua
@@ -128,8 +128,8 @@ function fluid_depot:update_contents()
     if not name then
       local box = self:get_output_fluidbox()
       if box then
-        content.name = box.name
-        content.count = box.amount
+        name = box.name
+        content = {name = box.name,count = box.amount,quality = ""}
       end
     end
     local signal

--- a/script/depots/fuel_depot.lua
+++ b/script/depots/fuel_depot.lua
@@ -99,8 +99,10 @@ end
 function fuel_depot:update_circuit_reader()
   if self.circuit_reader and self.circuit_reader.valid then
     local behavior = self.circuit_reader.get_or_create_control_behavior()
-    local signal = {signal = {type = "fluid", name = get_fuel_fluid()}, count = self:get_fuel_amount()}
-    behavior.set_signal(1, signal)
+    if (behavior.sections_count == 0) then behavior.add_section() end
+    local section = behavior.get_section(1)
+    local signal = {value = {type = "fluid", name = get_fuel_fluid(), quality = "normal"},  min = self:get_fuel_amount(), max = self:get_fuel_amount()}
+    section.set_slot(1, signal)
   end
 end
 


### PR DESCRIPTION
The content is nil value when name is nil. This makes a crash when write content.name = box.name.